### PR TITLE
Fix path who contain invalid char

### DIFF
--- a/base.php
+++ b/base.php
@@ -1717,8 +1717,7 @@ final class Base extends Prefab implements ArrayAccess {
 
 		// Check if the PATH contains only alphanumeric characters and slashes; if not, trigger a 404 error.
 		if (preg_replace('/[^a-zA-Z0-9\/]/', '', $this->hive['PATH']) !== $this->hive['PATH'])
-		$this->error(404);
-	
+			$this->error(404);
 	
 		$allowed=[];
 		foreach ($this->hive['ROUTES'] as $pattern=>$routes) {

--- a/base.php
+++ b/base.php
@@ -1714,6 +1714,12 @@ final class Base extends Prefab implements ArrayAccess {
 			$preflight=
 				isset($this->hive['HEADERS']['Access-Control-Request-Method']);
 		}
+
+		// Check if the PATH contains only alphanumeric characters and slashes; if not, trigger a 404 error.
+		if (preg_replace('/[^a-zA-Z0-9\/]/', '', $this->hive['PATH']) !== $this->hive['PATH'])
+		$this->error(404);
+	
+	
 		$allowed=[];
 		foreach ($this->hive['ROUTES'] as $pattern=>$routes) {
 			if (!$args=$this->mask($pattern,$req))

--- a/base.php
+++ b/base.php
@@ -1716,7 +1716,7 @@ final class Base extends Prefab implements ArrayAccess {
 		}
 
 		// Check if the PATH contains only alphanumeric characters and slashes; if not, trigger a 404 error.
-		if (preg_replace('/[^a-zA-Z0-9\/]/', '', $this->hive['PATH']) !== $this->hive['PATH'])
+		if (preg_replace('/[^a-zA-Z0-9\/-]/', '', $this->hive['PATH']) !== $this->hive['PATH'])
 			$this->error(404);
 	
 		$allowed=[];


### PR DESCRIPTION
Hello :) 

Ce petit fix pour éviter d'avoir des erreurs 500 lors d'un call api contenant des caractères invalides.
Exemple : 

apis/resources/12/information%0A

ERROR 500: Invalid class boondmanager\apis\deliveries\information - /api/deliveries/17/information%0A

Résultat : Si 500 -> retourne une 404