### PR TITLE
Avoid 500 on template generation when missing data

### DIFF
--- a/base.php
+++ b/base.php
@@ -2952,7 +2952,7 @@ class View extends Prefab {
 		$this->temp=NULL;
 		++$this->level;
 		ob_start();
-		require($this->file);
+		@require($this->file);
 		--$this->level;
 		return ob_get_clean();
 	}


### PR DESCRIPTION
Ce fix corrige les 500 lors de la génération de template avec des datas manquantes.

L'erreur en question : 

[main:500] ERROR 500: Trying to access array offset on value of type null

[vendor/bcosca/fatfree-core/base.php:1995] BoondManager\Services\BM::BoondManager\Services\{closure}()
[vendor/bcosca/fatfree-core/base.php:1401] Base->call()
[vendor/bcosca/fatfree-core/base.php:2388] Base->error()
[tmp/m4s624je4tgp.258ww2vk4xk0k.php:60] Base->{closure}()
[vendor/bcosca/fatfree-core/base.php:2953] require()
[vendor/bcosca/fatfree-core/base.php:3197] View->sandbox()

